### PR TITLE
Update density-mirror.ipynb

### DIFF
--- a/src/notebooks/density-mirror.ipynb
+++ b/src/notebooks/density-mirror.ipynb
@@ -120,7 +120,7 @@
     "plt.rcParams[\"figure.figsize\"]=12,8\n",
     "\n",
     "# plot histogram chart for var1\n",
-    "sns.histplot(x=df.var1, stat=\"density\", bins=20)\n",
+    "sns.histplot(x=df.var1, stat=\"density\", bins=20, edgecolor='black')\n",
     "\n",
     "# plot histogram chart for var2\n",
     "n_bins = 20\n",


### PR DESCRIPTION
In the second example, var1 plot's edgecolor is now set to black like how it's shown in the visual.