### PR TITLE
Update circular-packing-1-level-hierarchy.ipynb

### DIFF
--- a/src/notebooks/circular-packing-1-level-hierarchy.ipynb
+++ b/src/notebooks/circular-packing-1-level-hierarchy.ipynb
@@ -69,7 +69,9 @@
     "    df['Value'].tolist(), \n",
     "    show_enclosure=False, \n",
     "    target_enclosure=circlify.Circle(x=0, y=0, r=1)\n",
-    ")"
+    ")\n"
+    "# reverse the order of the circles to match the order of data\n"
+    "circles = circles[::-1]\n"
    ]
   },
   {


### PR DESCRIPTION
Added code to reverse the order of the circles in list to handle the wrong sort order.
Apparently circlify return the list of circles in ascending order and thereby showing the largest values in the smallest circles. 