### PR TITLE
Update 24-histogram-with-a-boxplot-on-top-seaborn.ipynb

### DIFF
--- a/src/notebooks/24-histogram-with-a-boxplot-on-top-seaborn.ipynb
+++ b/src/notebooks/24-histogram-with-a-boxplot-on-top-seaborn.ipynb
@@ -34,7 +34,7 @@
     "f, (ax_box, ax_hist) = plt.subplots(2, sharex=True, gridspec_kw={\"height_ratios\": (.15, .85)})\n",
     " \n",
     "# assigning a graph to each ax\n",
-    "sns.boxplot(df[\"sepal_length\"], ax=ax_box)\n",
+    "sns.boxplot(df[\"sepal_length\"], orient=\"h\", ax=ax_box)\n",
     "sns.histplot(data=df, x=\"sepal_length\", ax=ax_hist)\n",
     " \n",
     "# Remove x axis name for the boxplot\n",


### PR DESCRIPTION
seaborn version 0.12.2 plots the boxplot with vertical orientation, so it needs to be explicitly defined using the "orient" arg