### PR TITLE
add css for dataframe style

### DIFF
--- a/src/styles/basic.css
+++ b/src/styles/basic.css
@@ -1,3 +1,26 @@
-.blog-post-content h2{
-    padding-top: 100px;
+.blog-post-content h2 {
+  padding-top: 100px;
+}
+
+/* style for dataframe outputs */
+.dataframe {
+  color: #333;
+  width: 100%;
+  margin: 0 auto;
+  border-collapse: collapse;
+  border: 1px solid #333;
+}
+.dataframe th,
+.dataframe td {
+  border: 1px solid #666;
+  text-align: center !important;
+  vertical-align: middle;
+  font-size: 17px;
+}
+
+.dataframe th,
+.dataframe thead th {
+  background-color: #f5f5f5;
+  color: #333;
+  font-weight: bold;
 }


### PR DESCRIPTION
I added some css in basic.css so that we can more use the `df.head()` code for tutorials because pandas df are now better looking. 

*Note*:

- I added `text-align: center !important;` because column names have by default another styling inside html with `style` attribute that seem prioritised
- I didn't found any html element with `dataframe` class name so it shouldn't break anything

**Before**

<img width="863" alt="Screenshot 2024-04-11 at 09 57 19" src="https://github.com/holtzy/The-Python-Graph-Gallery/assets/79746670/95a165e9-3d1b-43ba-9cec-dfc53d3c470a">

**After**

<img width="910" alt="Screenshot 2024-04-11 at 09 54 53" src="https://github.com/holtzy/The-Python-Graph-Gallery/assets/79746670/bb7c13f0-fc2c-4633-8b58-01a881c810c9">
